### PR TITLE
BUG: set current locale when fetching editable widget segment

### DIFF
--- a/code/model/Widget.php
+++ b/code/model/Widget.php
@@ -211,6 +211,12 @@ class Widget_Controller extends Controller {
 	 */
 	function editablesegment() {
 		$className = $this->urlParams['ID'];
+		if (class_exists('Translatable') && Member::currentUserID()) {
+			// set current locale based on logged in user's locale
+			$locale = Member::currentUser()->Locale;
+			Translatable::set_current_locale($locale);
+			i18n::set_locale($locale);
+		}
 		if(class_exists($className) && is_subclass_of($className, 'Widget')) {
 			$obj = new $className();
 			return $obj->EditableSegment();


### PR DESCRIPTION
Set the current locale before rendering the editable widget segment
(if the Translatable module is installed)
