### PR TITLE
ENHANCEMENT: Made title, cmstitle and description on widgets translatable

### DIFF
--- a/code/model/Widget.php
+++ b/code/model/Widget.php
@@ -65,15 +65,15 @@ class Widget extends DataObject {
 	}
 	
 	function Title() {
-		return Object::get_static($this->class, 'title');
+		return _t($this->class.'.TITLE', Object::get_static($this->class, 'title'));
 	}
 	
 	function CMSTitle() {
-		return Object::get_static($this->class, 'cmsTitle');
+		return _t($this->class.'.CMSTITLE', Object::get_static($this->class, 'cmsTitle'));
 	}
 	
 	function Description() {
-		return Object::get_static($this->class, 'description');
+		return _t($this->class.'.DESCRIPTION', Object::get_static($this->class, 'description'));
 	}
 	
 	function DescriptionSegment() {


### PR DESCRIPTION
Made title, cmsTitle and description properties translatable for widgets by using the _t() function
in the properties respective getters (using the static property as the default translation as not
to change the behaviour when no translations exist). Uppercase TITLE, CMSTITLE and DESCRIPTION
translation strings used...
