### PR TITLE
Added forTemplate function on Widget

### DIFF
--- a/code/model/Widget.php
+++ b/code/model/Widget.php
@@ -95,6 +95,17 @@ class Widget extends DataObject {
 	public function WidgetHolder() {
 		return $this->renderWith("WidgetHolder");
 	}
+
+	/**
+	 * Default way to render widget in templates.
+	 * @return string HTML
+	 */
+	public function forTemplate($holder = true){
+		if($holder){
+			return $this->WidgetHolder();
+		}
+		return $this->Content();
+	}
 	
 	/**
 	 * Renders the widget content in a custom template with the same name as the 


### PR DESCRIPTION
This makes it easier to render widgets in templates. An argument gives the option to use the widget holder or not. By default, the holder is used.
