### PR TITLE
Change of yml name

### DIFF
--- a/_config/contentcontroller-url-handler.yml
+++ b/_config/contentcontroller-url-handler.yml
@@ -1,5 +1,5 @@
 ---
-Name: contentcontroller-url-handler
+Name: contentcontrollerurlhandler
 ---
 ContentController:
   extensions:


### PR DESCRIPTION
Changed contentcontroller-url-handler to contentcontrollerurlhandler so that it can be overridden. For some reason this wont work with hyphens in the name.
