### PR TITLE
BUG Fixed issue with nested InheritSideBar not inheriting beyond the first level

### DIFF
--- a/code/extension/WidgetPageExtension.php
+++ b/code/extension/WidgetPageExtension.php
@@ -38,11 +38,11 @@ class WidgetPageExtension extends DataExtension {
 	 */
 	public function SideBarView() {
 		if(
-			$this->owner->InheritSideBar 
-			&& $this->owner->getParent() 
-			&& $this->owner->getParent()->hasMethod('SideBar')
+			$this->owner->InheritSideBar
+			&& ($parent = $this->owner->getParent())
+			&& $parent->hasMethod('SideBarView')
 		) {
-			return $this->owner->getParent()->SideBar();
+			return $parent->SideBarView();
 		} elseif($this->owner->SideBar()->exists()){
 			return $this->owner->SideBar();
 		}


### PR DESCRIPTION
If you have a tree structure like:
- BlogSet
  - BlogHolder
    - BlogEntry

And setup a sidebar on the BlogSet, then set InheritSideBar on both the holder and entry, viewing the BlogEntry page shows no sidebar. This is because the sidebar can only inherit up to one level.

This fix makes the inheritance recursive.
