### PR TITLE
NEW Adding support for Translatable

### DIFF
--- a/code/extension/WidgetPageExtension.php
+++ b/code/extension/WidgetPageExtension.php
@@ -48,4 +48,12 @@ class WidgetPageExtension extends DataExtension {
 		}
 	}
 
+	/**
+	 * Support Translatable so that we don't link WidgetAreas across translations
+	 */
+	public function onTranslatableCreate() {
+		//reset the sidebar ID
+		$this->owner->SideBarID = 0;
+	}
+
 }


### PR DESCRIPTION
At the moment, when using Translatable on a site, if you use the Tranlate tab to create a translated version of the page, the WidgetAreaID is retained and you experience the same issue as reported in #58

Related to: #59
