### PR TITLE
FIX Setting `$only_available_in` to `private` visibility

### DIFF
--- a/code/model/Widget.php
+++ b/code/model/Widget.php
@@ -27,7 +27,7 @@ class Widget extends DataObject {
 		'Enabled' => true
 	);
 	
-	public static $only_available_in = array();
+	private static $only_available_in = array();
 
 	/**
 	 * @var array


### PR DESCRIPTION
Config engine throws deprecation warnings when this is accessed through the Config engine
