### PR TITLE
Re-add getCMSFields, inherit scaffolding, remove Sort & ParentID fields, add Enabled

### DIFF
--- a/code/model/Widget.php
+++ b/code/model/Widget.php
@@ -78,6 +78,13 @@ class Widget extends DataObject {
 		'CMSTitle' => 'Title'
 	);
 
+	public function getCMSFields(){
+                $fields = parent::getCMSFields();
+                $fields->removeByName(array('Sort', 'ParentID'));
+                $fields->push(CheckboxField::create('Enabled'));
+                return $fields;
+	}
+     
 	/**
 	 * @var WidgetController
 	 */


### PR DESCRIPTION
This prevents the need for removing 'Sort'/'ParentID' fields & adding 'Enabled' by default.
'Enabled' works with https://github.com/silverstripe/silverstripe-widgets/pull/73
