### PR TITLE
API Enable Title to be CMS driven

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,11 @@ blank). Each widget should be in its own folder like widgets_widgetName/
 After installing or creating a new widget, **make sure to run db/build?flush=1** at the end of the URL, *before*
 attempting to use it.
 
-The class should extend the Widget class, and must specify three static variables - $title, the title that will appear
-in the rendered widget (eg Photos), $cmsTitle, a more descriptive title that will appear in the cms editor (eg Flickr
-Photos), and $description, a short description that will appear in the cms editor (eg This widget shows photos from
+The class should extend the Widget class, and must specify three config variables:
+
+* `title`: The title that will appear in the rendered widget (eg Photos). This can be customised by the CMS admin
+* `cmsTitle`: a more descriptive title that will appear in the cms editor (eg Flickr Photos)
+* `description`: a short description that will appear in the cms editor (eg This widget shows photos from
 Flickr). The class may also specify functions to be used in the template like a page type can.
 
 If a Widget has configurable options, then it can specify a number of database fields to store these options in via the

--- a/code/model/Widget.php
+++ b/code/model/Widget.php
@@ -16,15 +16,24 @@ class Widget extends DataObject {
 	 * @var array
 	 */
 	private static $db = array(
+		"Title" => "Varchar(255)",
 		"Sort" => "Int",
-		"Enabled" => "Boolean"
+		"Enabled" => "Boolean",
 	);
 
 	/**
 	 * @var array
 	 */
 	private static $defaults = array(
-		'Enabled' => true
+		'Enabled' => true,
+	);
+
+	/**
+	 * @var array
+	 */
+	private static $casting = array(
+		'CMSTitle' => 'Text',
+		'Description' => 'Text',
 	);
 	
 	private static $only_available_in = array();
@@ -35,21 +44,6 @@ class Widget extends DataObject {
 	private static $has_one = array(
 		"Parent" => "WidgetArea",
 	);
-
-	/**
-	 * @var array
-	 */
-	private static $has_many = array();
-
-	/**
-	 * @var array
-	 */
-	private static $many_many = array();
-
-	/**
-	 * @var array
-	 */
-	private static $belongs_many_many = array();
 
 	/**
 	 * @var string
@@ -82,6 +76,11 @@ class Widget extends DataObject {
 	 * @var WidgetController
 	 */
 	protected $controller;
+
+	public function populateDefaults() {
+		parent::populateDefaults();
+		$this->setField('Title', $this->getTitle());
+	}
 	
 	/**
 	 * Note: Overloaded in {@link WidgetController}.
@@ -120,22 +119,49 @@ class Widget extends DataObject {
 
 	/**
 	 * @return string
+	 * @deprecated
 	 */
 	public function Title() {
-		return _t($this->class.'.TITLE', $this->config()->title);
+		return $this->getTitle();
+	}
+
+	/**
+	 * Get the frontend title for this widget
+	 *
+	 * @return string
+	 */
+	public function getTitle() {
+		return $this->getField('Title')
+			?: _t($this->class.'.TITLE', $this->config()->title);
+	}
+
+	/**
+	 * @return string
+	 * @deprecated
+	 */
+	public function CMSTitle() {
+		return $this->getCMSTitle();
 	}
 
 	/**
 	 * @return string
 	 */
-	public function CMSTitle() {
+	public function getCMSTitle() {
 		return _t($this->class.'.CMSTITLE', $this->config()->cmsTitle);
 	}
 
 	/**
 	 * @return string
+	 * @deprecated
 	 */
 	public function Description() {
+		return $this->getDescription();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getDescription() {
 		return _t($this->class.'.DESCRIPTION', $this->config()->description);
 	}
 
@@ -159,10 +185,11 @@ class Widget extends DataObject {
 	 * @return FieldList
 	 */
 	public function getCMSFields() {
-		$fields = parent::getCMSFields();
-		$fields->removeByName('ParentID');
-		$fields->removeByName('Sort');
-		
+		$fields = new FieldList(
+			new TextField('Title', $this->fieldLabel('Title'), null, 255),
+			new CheckboxField('Enabled', $this->fieldLabel('Enabled'))
+		);
+		$this->extend('updateCMSFields', $fields);
 		return $fields;
 	}
 	

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.0.x-dev"
+			"dev-master": "1.1.x-dev"
 		}
 	}
 }

--- a/tests/WidgetAreaEditorTest.php
+++ b/tests/WidgetAreaEditorTest.php
@@ -439,15 +439,4 @@ class WidgetAreaEditorTest_TestWidget extends Widget implements TestOnly {
 	private static $cmsTitle = "Test widget";
 	private static $title = "Test widget";
 	private static $description = "Test widget";
-	private static $db = array(
-		'Title' => 'Varchar'
-	);
-	public function getCMSFields() {
-		$fields = new FieldList();
-		$fields->push(new TextField('Title'));
-		return $fields;
-	}
-	function Title() {
-		return $this->Title ? $this->Title : self::$title;
-	}
 }


### PR DESCRIPTION
FIX issue with field scaffolding hiding the "Enabled" checkbox
FIX Safe escaping of CMSTitle / Description fields

In just about every widget it's necessary to add a custom CMS field to set the title, so this has been put in core.

I would possibly suggest merging this AFTER https://github.com/silverstripe/silverstripe-widgets/pull/83, and making a new branch prior to the merge in order to maintain backwards compatibility. 1.0 being the branch without CMS title (as it exists) and master (aliased as 1.1) could have the new feature.