### PR TITLE
BUGFIX: Fixed issue where Widget::CMSEditor() can't rename the enabled checkbox

### DIFF
--- a/code/model/Widget.php
+++ b/code/model/Widget.php
@@ -159,9 +159,17 @@ class Widget extends DataObject {
 	 * @return FieldList
 	 */
 	public function getCMSFields() {
-		$fields = parent::getCMSFields();
+		$fields = $this->scaffoldFormFields(array(
+			// Don't allow has_many/many_many relationship editing before the record is first saved
+			'includeRelations' => ($this->ID > 0),
+			'tabbed' => false,
+			'ajaxSafe' => true
+		));
+		
 		$fields->removeByName('ParentID');
 		$fields->removeByName('Sort');
+		
+		$this->extend('updateCMSFields', $tabbedFields);
 		
 		return $fields;
 	}


### PR DESCRIPTION
When saving a widget the Enabled checkbox is present in the form but it does not get renamed by Widget::CMSEditor() since it is nested in a tabset. This causes the enabled checkbox be hidden after saving the widget for the first time. Oddly this also unchecks the checkbox, so the next time the holder page/object its saved the widget becomes disabled and no longer shows on the front end.