### PR TITLE
Move 3.2+ compat version to 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
 		}
 	],
 	"require": {
-		"silverstripe/framework": "~3.2,~4.0",
-		"silverstripe/cms": "~3.2,~4.0"
+		"silverstripe/framework": ">=3.2",
+		"silverstripe/cms": ">=3.2"
 	},
 	"require-dev": {
 		"phpunit/PHPUnit": "~3.7@stable"
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.1.x-dev"
+			"dev-master": "1.2.x-dev"
 		}
 	}
 }


### PR DESCRIPTION
The new Title behaviour (which required a new version over 1.0) should stay 3.1 compatible, and has been branched into 1.1 at https://github.com/silverstripe/silverstripe-widgets/tree/1.1