### PR TITLE
BUG Prevent non-widget tests from loading WidgetAreaEditorTest_FakePage every query

### DIFF
--- a/tests/WidgetAreaEditorTest.php
+++ b/tests/WidgetAreaEditorTest.php
@@ -15,6 +15,12 @@ class WidgetAreaEditorTest extends SapphireTest {
 	);
 	
 	protected $usesDatabase = true;
+
+	protected $requiredExtensions = array(
+		"SiteTree" => array(
+			"WidgetPageExtension"
+		)
+	);
 	
 	function testFillingOneArea() {
 		$data = array(
@@ -430,7 +436,6 @@ class WidgetAreaEditorTest extends SapphireTest {
 
 class WidgetAreaEditorTest_FakePage extends Page implements TestOnly {
 	private static $has_one = array(
-		"SideBar" => "WidgetArea",
 		"BottomBar" => "WidgetArea",
 	);
 }


### PR DESCRIPTION
The problem is that this Page subclass added a column which is also present in a sitetree extension.

If a test in another module runs, when this extension is enabled, it will include the "SideBarID" in the query, which can occasionally force this table to be essentially left-joined into every query.

This can crash tests that did not have this class included in the "extraDataObjects" property, and thus will crash on these queries where that table doesn't exist.