### PR TITLE
Remove invalid 3.1 test fixture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
     - php: 5.6
       env: DB=MYSQL CORE_RELEASE=3
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.1
-    - php: 5.6
       env: DB=PGSQL CORE_RELEASE=3.2
   allow_failures:
     - php: 7.0


### PR DESCRIPTION
This branch requires ~3.2 so this isn't going to be testable anyway.