### PR TITLE
#125 - FIX: disconnect tinyMCE while dragging

### DIFF
--- a/javascript/WidgetAreaEditor.js
+++ b/javascript/WidgetAreaEditor.js
@@ -26,13 +26,13 @@
 					placeholder: 'ui-state-highlight',
 					forcePlaceholderSize: true,
 					start: function (e, ui) {
-						htmleditors = $(e.srcElement).closest('.Widget').find('textarea.htmleditor');
+						htmleditors = $(ui.item).closest('.Widget').find('textarea.htmleditor');
 						$.each(htmleditors, function (k, i) {
 							tinyMCE.execCommand('mceRemoveControl', false, $(i).attr('id'));
 						})
 					},
 					stop: function (e, ui) {
-						htmleditors = $(e.srcElement).closest('.Widget').find('textarea.htmleditor');
+						htmleditors = $(ui.item).closest('.Widget').find('textarea.htmleditor');
 						$.each(htmleditors, function (k, i) {
 							tinyMCE.execCommand('mceAddControl', true, $(i).attr('id'));
 						})

--- a/javascript/WidgetAreaEditor.js
+++ b/javascript/WidgetAreaEditor.js
@@ -20,9 +20,23 @@
 				$(this).find('.usedWidgets').sortable({
 					opacity: 0.6,
 					handle: '.handle',
-					update: function(e, ui) {parentRef.updateWidgets(e, ui)},
+					update: function (e, ui) {
+						parentRef.updateWidgets(e, ui)
+					},
 					placeholder: 'ui-state-highlight',
-					forcePlaceholderSize: true
+					forcePlaceholderSize: true,
+					start: function (e, ui) {
+						htmleditors = $(e.srcElement).closest('.Widget').find('textarea.htmleditor');
+						$.each(htmleditors, function (k, i) {
+							tinyMCE.execCommand('mceRemoveControl', false, $(i).attr('id'));
+						})
+					},
+					stop: function (e, ui) {
+						htmleditors = $(e.srcElement).closest('.Widget').find('textarea.htmleditor');
+						$.each(htmleditors, function (k, i) {
+							tinyMCE.execCommand('mceAddControl', true, $(i).attr('id'));
+						})
+					}
 				});
 				
 				// Figure out maxid, this is used when creating new widgets


### PR DESCRIPTION
By disconnecting the tinyMCE it won't trigger a recreate after drag and dropping, so you won't wind up with multiple htmleditors.