### PR TITLE
use already fetched value

### DIFF
--- a/javascript/WidgetAreaEditor.js
+++ b/javascript/WidgetAreaEditor.js
@@ -5,7 +5,7 @@
 				var parentName=$(this).attr('name');
 				this.rewriteWidgetAreaAttributes();
 
-				var availableWidgets=$('#availableWidgets-'+$(this).attr('name')).children().each(function() {
+				var availableWidgets=$('#availableWidgets-'+parentName).children().each(function() {
 					// Don't run on comments, whitespace, etc
 					if($(this)[0].nodeType==1) {
 						// Gotta change their ID's because otherwise we get clashes between two tabs


### PR DESCRIPTION
unrelated:
I see that `$(this)` is used inside enwtine option method scope, but i believe that `this` is alread a jQuery object like when defining jQuery plugins, so for instance `this.attr('name')` should work fine as well.
kind regards

