### PR TITLE
FIX convert CI bootstrap references to new their new locations in vendor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=framework/phpcs.xml.dist src/ tests/ ; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=vendor/silverstripe/framework/phpcs.xml.dist src/ tests/ ; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<phpunit bootstrap="cms/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
     <testsuite name="Default">
         <directory>tests</directory>
     </testsuite>

--- a/tests/WidgetControllerTest/TestPageController.php
+++ b/tests/WidgetControllerTest/TestPageController.php
@@ -19,12 +19,7 @@ class TestPageController extends PageController implements TestOnly
      */
     public function getViewer($action)
     {
-        if (file_exists('widgets')) {
-            SSViewer::add_themes(['silverstripe/widgets:tests/WidgetControllerTest']);
-        } else {
-            // When installed as the root project, e.g. Travis
-            SSViewer::add_themes(['tests/WidgetControllerTest']);
-        }
+        SSViewer::add_themes(['silverstripe/widgets:/tests/WidgetControllerTest']);
         return new SSViewer(TestPage::class);
     }
 }


### PR DESCRIPTION
Following on from the move yesterday to host SilverStripe core (4.0+) from `vendor` and in the future from outside the webroot, the according adjustments are being made to all the CI and unit testing bootstrapping files in SilverStripe's supported & most commonly used modules to allow automated tests to continue passing.