### PR TITLE
FIX Ensure namespaced widget classes are handled and Widget is not included

### DIFF
--- a/src/Controllers/WidgetController.php
+++ b/src/Controllers/WidgetController.php
@@ -135,15 +135,11 @@ class WidgetController extends Controller
     {
         // use left and main to set the html config
         $leftandmain = LeftAndMain::create();
+        $leftandmain->setRequest($this->getRequest());
         $leftandmain->doInit();
 
         // Decode if fully qualified - @see Widget::ClassName
         $className = str_replace('_', '\\', $this->urlParams['ID']);
-        if (class_exists('Translatable') && Member::currentUserID()) {
-            // set current locale based on logged in user's locale
-            $locale = Member::currentUser()->Locale;
-            i18n::set_locale($locale);
-        }
         if (class_exists($className) && is_subclass_of($className, Widget::class)) {
             $obj = new $className();
             return $obj->EditableSegment();

--- a/src/Extensions/WidgetPageExtension.php
+++ b/src/Extensions/WidgetPageExtension.php
@@ -75,13 +75,4 @@ class WidgetPageExtension extends DataExtension
 
         return $duplicatePage;
     }
-
-    /**
-     * Support Translatable so that we don't link WidgetAreas across translations
-     */
-    public function onTranslatableCreate()
-    {
-        //reset the sidebar ID
-        $this->owner->SideBarID = 0;
-    }
 }

--- a/src/Forms/WidgetAreaEditor.php
+++ b/src/Forms/WidgetAreaEditor.php
@@ -10,7 +10,6 @@ use SilverStripe\Forms\FormField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\View\Requirements;
-use SilverStripe\Widgets\Forms\WidgetAreaEditor;
 use SilverStripe\Widgets\Model\Widget;
 
 /**
@@ -57,8 +56,8 @@ class WidgetAreaEditor extends FormField
         foreach ($this->widgetClasses as $widgetClass) {
             $classes = ClassInfo::subclassesFor($widgetClass);
 
-            if (isset($classes[Widget::class])) {
-                unset($classes[Widget::class]);
+            if (isset($classes[strtolower(Widget::class)])) {
+                unset($classes[strtolower(Widget::class)]);
             } elseif (isset($classes[0]) && $classes[0] == Widget::class) {
                 unset($classes[0]);
             }
@@ -164,6 +163,12 @@ class WidgetAreaEditor extends FormField
                         unset($missingWidgets[$widget->ID]);
                     }
                 }
+
+                // unsantise the class name
+                if (empty($newWidgetData['Type'])) {
+                    $newWidgetData['Type'] = '';
+                }
+                $newWidgetData['Type'] = str_replace('_', '\\', $newWidgetData['Type']);
 
                 // create a new object
                 if (!$widget


### PR DESCRIPTION
This change:

* Ensures that the stub LeftAndMain instance has a request with a session (fixes #159)
* Unescapes namespaced classes when creating a widget (Type argument)
* Removes Translatable related code

