### PR TITLE
 API Widgets and WidgetAreas are versioned and are owned by pages

### DIFF
--- a/.upgrade.yml
+++ b/.upgrade.yml
@@ -1,16 +1,7 @@
 mappings:
   WidgetContentControllerExtension: SilverStripe\Widgets\Controllers\WidgetContentControllerExtension
-  WidgetController: SilverStripe\Widgets\Controllers\WidgetController
-  Widget_Controller: SilverStripe\Widgets\Controllers\Widget_Controller
+  Widget_Controller: SilverStripe\Widgets\Models\WidgetController
   WidgetPageExtension: SilverStripe\Widgets\Extensions\WidgetPageExtension
   WidgetAreaEditor: SilverStripe\Widgets\Forms\WidgetAreaEditor
   Widget: SilverStripe\Widgets\Model\Widget
   WidgetArea: SilverStripe\Widgets\Model\WidgetArea
-  WidgetAreaEditorTest: SilverStripe\Widgets\Tests\WidgetAreaEditorTest
-  WidgetAreaEditorTest_FakePage: SilverStripe\Widgets\Tests\WidgetAreaEditorTest\FakePage
-  WidgetAreaEditorTest_TestWidget: SilverStripe\Widgets\Tests\WidgetAreaEditorTest\TestWidget
-  WidgetControllerTest: SilverStripe\Widgets\Tests\WidgetControllerTest
-  WidgetControllerTest_Widget: SilverStripe\Widgets\Tests\WidgetControllerTest\TestWidget
-  WidgetControllerTest_WidgetController: SilverStripe\Widgets\Tests\WidgetControllerTest\TestWidgetController
-  WidgetControllerTestPage: SilverStripe\Widgets\Tests\WidgetControllerTest\TestPage
-  WidgetControllerTestPage_Controller: SilverStripe\Widgets\Tests\WidgetControllerTest\TestPageController

--- a/_config/contentcontroller-url-handler.yml
+++ b/_config/contentcontroller-url-handler.yml
@@ -1,5 +1,5 @@
 ---
-Name: contentcontrollerurlhandler
+Name: widgetscontentcontrollerurlhandler
 ---
 SilverStripe\CMS\Controllers\ContentController:
   extensions:

--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -1,3 +1,6 @@
+---
+Name: widgetsroutes
+---
 SilverStripe\Control\Director:
   rules:
     'WidgetController//$Action/$ID/$OtherID': 'SilverStripe\Widgets\Controllers\WidgetController'

--- a/_config/routes.yml
+++ b/_config/routes.yml
@@ -3,4 +3,4 @@ Name: widgetsroutes
 ---
 SilverStripe\Control\Director:
   rules:
-    'WidgetController//$Action/$ID/$OtherID': 'SilverStripe\Widgets\Controllers\WidgetController'
+    'WidgetController//$Action/$ID/$OtherID': 'SilverStripe\Widgets\Model\WidgetController'

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "silverstripe/vendor-plugin": "^1.0",
         "silverstripe/framework": "^4.0",
-        "silverstripe/cms": "^4.0"
+        "silverstripe/cms": "^4.0",
+        "silverstripe/versioned": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",

--- a/src/Extensions/WidgetPageExtension.php
+++ b/src/Extensions/WidgetPageExtension.php
@@ -19,17 +19,25 @@ use SilverStripe\Widgets\Model\WidgetArea;
  */
 class WidgetPageExtension extends DataExtension
 {
-    private static $db = array(
+    private static $db = [
         'InheritSideBar' => 'Boolean',
-    );
+    ];
 
-    private static $defaults = array(
+    private static $defaults = [
         'InheritSideBar' => true
-    );
+    ];
 
-    private static $has_one = array(
-        'SideBar' => WidgetArea::class
-    );
+    private static $has_one = [
+        'SideBar' => WidgetArea::class,
+    ];
+
+    private static $owns = [
+        'SideBar',
+    ];
+
+    private static $cascade_deletes = [
+        'SideBar',
+    ];
 
     public function updateCMSFields(FieldList $fields)
     {

--- a/src/Model/Widget.php
+++ b/src/Model/Widget.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\Widgets\Model;
 
 use Exception;
+use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\CheckboxField;
@@ -10,6 +11,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
 
 /**
  * Widgets let CMS authors drag and drop small pieces of functionality into
@@ -23,42 +25,27 @@ use SilverStripe\ORM\DataObject;
  */
 class Widget extends DataObject
 {
-    /**
-     * @var array
-     */
-    private static $db = array(
+    private static $db = [
         "Title" => "Varchar(255)",
         "Sort" => "Int",
         "Enabled" => "Boolean",
-    );
+    ];
 
-    /**
-     * @var array
-     */
-    private static $defaults = array(
+    private static $defaults = [
         'Enabled' => true,
-    );
+    ];
 
-    /**
-     * @var array
-     */
-    private static $casting = array(
+    private static $casting = [
         'CMSTitle' => 'Text',
         'Description' => 'Text',
-    );
+    ];
 
-    private static $only_available_in = array();
+    private static $only_available_in = [];
 
-    /**
-     * @var array
-     */
-    private static $has_one = array(
+    private static $has_one = [
         "Parent" => WidgetArea::class,
-    );
+    ];
 
-    /**
-     * @var string
-     */
     private static $default_sort = "\"Sort\"";
 
     /**
@@ -76,17 +63,15 @@ class Widget extends DataObject
      */
     private static $description = "Description of what this widget does.";
 
-    /**
-     * @var array
-     */
-    private static $summary_fields = array(
+    private static $summary_fields = [
         'CMSTitle' => 'Title'
-    );
+    ];
 
-    /**
-     * @var string
-     */
     private static $table_name = 'Widget';
+
+    private static $extensions = [
+        Versioned::class . '.versioned',
+    ];
 
     /**
      * @var WidgetController
@@ -267,10 +252,13 @@ class Widget extends DataObject
         }
 
         if (!class_exists($controllerClass)) {
-            throw new Exception('Could not find controller class for ' . $controllerClass);
+            throw new Exception('Could not find controller class for ' . static::class);
         }
 
         $this->controller = Injector::inst()->create($controllerClass, $this);
+        if (Injector::inst()->has(HTTPRequest::class)) {
+            $this->controller->setRequest(Injector::inst()->get(HTTPRequest::class));
+        }
 
         return $this->controller;
     }

--- a/src/Model/Widget.php
+++ b/src/Model/Widget.php
@@ -70,7 +70,7 @@ class Widget extends DataObject
     private static $table_name = 'Widget';
 
     private static $extensions = [
-        Versioned::class . '.versioned',
+        Versioned::class,
     ];
 
     /**

--- a/src/Model/WidgetArea.php
+++ b/src/Model/WidgetArea.php
@@ -27,7 +27,7 @@ class WidgetArea extends DataObject
     ];
 
     private static $extensions = [
-        Versioned::class . '.versioned',
+        Versioned::class,
     ];
 
     private static $table_name = 'WidgetArea';

--- a/src/Model/WidgetArea.php
+++ b/src/Model/WidgetArea.php
@@ -2,32 +2,36 @@
 
 namespace SilverStripe\Widgets\Model;
 
+use SilverStripe\Control\Controller;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\Versioned\Versioned;
 
 /**
  * Represents a set of widgets shown on a page.
- *
- * @package widgets
  */
 class WidgetArea extends DataObject
 {
-    /**
-     * @var array
-     */
-    private static $has_many = array(
+    private static $has_many = [
         "Widgets" => Widget::class
-    );
+    ];
 
-    /**
-     * @var string
-     */
+    private static $owns = [
+        'Widgets',
+    ];
+
+    private static $cascade_deletes = [
+        'Widgets',
+    ];
+
+    private static $extensions = [
+        Versioned::class . '.versioned',
+    ];
+
     private static $table_name = 'WidgetArea';
 
-    /**
-     *
-     * @var string
-     */
     public $template = __CLASS__;
 
     /**
@@ -43,6 +47,9 @@ class WidgetArea extends DataObject
         $items = $this->ItemsToRender();
         if (!is_null($items)) {
             foreach ($items as $widget) {
+                /** @var Widget $widget */
+
+                /** @var Controller $controller */
                 $controller = $widget->getController();
 
                 $controller->doInit();
@@ -57,7 +64,7 @@ class WidgetArea extends DataObject
      */
     public function Items()
     {
-        return $this->getComponents('Widgets');
+        return $this->Widgets();
     }
 
     /**
@@ -65,8 +72,7 @@ class WidgetArea extends DataObject
      */
     public function ItemsToRender()
     {
-        return $this->getComponents('Widgets')
-            ->filter("Enabled", 1);
+        return $this->Items()->filter('Enabled', 1);
     }
 
     /**
@@ -84,16 +90,5 @@ class WidgetArea extends DataObject
     public function setTemplate($template)
     {
         $this->template = $template;
-    }
-
-    /**
-     * Delete all connected Widgets when this WidgetArea gets deleted
-     */
-    public function onBeforeDelete()
-    {
-        parent::onBeforeDelete();
-        foreach ($this->Widgets() as $widget) {
-            $widget->delete();
-        }
     }
 }

--- a/src/Model/WidgetController.php
+++ b/src/Model/WidgetController.php
@@ -1,12 +1,11 @@
 <?php
 
-namespace SilverStripe\Widgets\Controllers;
+namespace SilverStripe\Widgets\Model;
 
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\ClassInfo;
-use SilverStripe\Widgets\Model\Widget;
 
 /**
  * Optional controller for every widget which has its own logic, e.g. in forms.

--- a/tests/WidgetControllerTest.php
+++ b/tests/WidgetControllerTest.php
@@ -3,14 +3,9 @@
 namespace SilverStripe\Widgets\Tests;
 
 use SilverStripe\Dev\FunctionalTest;
-use SilverStripe\Forms\Form;
 use SilverStripe\Widgets\Tests\WidgetControllerTest\TestPage;
 use SilverStripe\Widgets\Tests\WidgetControllerTest\TestWidget;
 
-/**
- * @package widgets
- * @subpackage tests
- */
 class WidgetControllerTest extends FunctionalTest
 {
     protected static $fixture_file = 'WidgetControllerTest.yml';
@@ -20,11 +15,18 @@ class WidgetControllerTest extends FunctionalTest
         TestWidget::class,
     ];
 
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->actWithPermission('ADMIN', function () {
+            $this->objFromFixture(TestPage::class, 'page1')->publishRecursive();
+        });
+    }
+
     public function testWidgetFormRendering()
     {
         $page = $this->objFromFixture(TestPage::class, 'page1');
-        $page->copyVersionToStage('Stage', 'Live');
-
         $widget = $this->objFromFixture(TestWidget::class, 'widget1');
 
         $response = $this->get($page->URLSegment);
@@ -40,11 +42,9 @@ class WidgetControllerTest extends FunctionalTest
     public function testWidgetFormSubmission()
     {
         $page = $this->objFromFixture(TestPage::class, 'page1');
-        $page->copyVersionToStage('Stage', 'Live');
-
         $widget = $this->objFromFixture(TestWidget::class, 'widget1');
 
-        $response = $this->get($page->URLSegment);
+        $this->get($page->URLSegment);
         $response = $this->submitForm('Form_Form', null, array('TestValue' => 'Updated'));
 
         $this->assertContains(

--- a/tests/WidgetControllerTest/TestPage.php
+++ b/tests/WidgetControllerTest/TestPage.php
@@ -4,18 +4,17 @@ namespace SilverStripe\Widgets\Tests\WidgetControllerTest;
 
 use Page;
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\View\SSViewer;
 use SilverStripe\Widgets\Model\WidgetArea;
 
-/**
- * @package cms
- * @subpackage tests
- */
 class TestPage extends Page implements TestOnly
 {
     private static $table_name = 'TestPage';
 
-    private static $has_one = array(
-        'WidgetControllerTestSidebar' => WidgetArea::class
-    );
+    private static $has_one = [
+        'WidgetControllerTestSidebar' => WidgetArea::class,
+    ];
+
+    private static $owns = [
+        'WidgetControllerTestSidebar',
+    ];
 }

--- a/tests/WidgetControllerTest/TestWidget.php
+++ b/tests/WidgetControllerTest/TestWidget.php
@@ -5,15 +5,11 @@ namespace SilverStripe\Widgets\Tests\WidgetControllerTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\Widgets\Model\Widget;
 
-/**
- * @package widgets
- * @subpackage tests
- */
 class TestWidget extends Widget implements TestOnly
 {
     private static $table_name = 'WidgetControllerTest_TestWidget';
 
-    private static $db = array(
-        'TestValue' => 'Text'
-    );
+    private static $db = [
+        'TestValue' => 'Text',
+    ];
 }

--- a/tests/WidgetControllerTest/TestWidgetController.php
+++ b/tests/WidgetControllerTest/TestWidgetController.php
@@ -7,7 +7,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\TextField;
-use SilverStripe\Widgets\Controllers\WidgetController;
+use SilverStripe\Widgets\Model\WidgetController;
 
 /**
  * @package widgets


### PR DESCRIPTION
- [x] **Note:** contains the commits from #162 which needs to be merged first.

This pull request changes the following:

* Array syntax
* Remove pointless doc blocks (where inherited ones would be more descriptive)
* Add Versioned to WidgetArea and Widget to track changes
* Implement Page ownership of WidgetArea and WidgetArea ownership of Widgets, with cascading deletes (removed custom code for this)
* Moved WidgetController into Widget's namespace since it's expected to be there to work (see `Widget::getController`)

Resolves #148 