### PR TITLE
API Remove overriding function getTitle()

### DIFF
--- a/src/Model/Widget.php
+++ b/src/Model/Widget.php
@@ -11,6 +11,7 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\HiddenField;
 use SilverStripe\Forms\TextField;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Versioned\Versioned;
 
 /**
@@ -47,11 +48,6 @@ class Widget extends DataObject
     ];
 
     private static $default_sort = "\"Sort\"";
-
-    /**
-     * @var string
-     */
-    private static $title = "Widget Title";
 
     /**
      * @var string
@@ -121,17 +117,6 @@ class Widget extends DataObject
     public function Content()
     {
         return $this->renderWith(array_reverse(ClassInfo::ancestry(__CLASS__)));
-    }
-
-    /**
-     * Get the frontend title for this widget
-     *
-     * @return string
-     */
-    public function getTitle()
-    {
-        return $this->getField('Title')
-            ?: _t(__CLASS__ . '.TITLE', $this->config()->get('title'));
     }
 
     /**

--- a/tests/WidgetAreaEditorTest/TestWidget.php
+++ b/tests/WidgetAreaEditorTest/TestWidget.php
@@ -9,6 +9,5 @@ class TestWidget extends Widget implements TestOnly
 {
     private static $table_name = 'WidgetAreaEditorTest_TestWidget';
     private static $cmsTitle = "Test widget";
-    private static $title = "Test widget";
     private static $description = "Test widget";
 }


### PR DESCRIPTION
In the case that no title is entered in the CMS's title field no title is returned. Resolves #141 